### PR TITLE
Add kmod-nat46

### DIFF
--- a/openwrt-23.05/seed/ao-R5S-full.seed
+++ b/openwrt-23.05/seed/ao-R5S-full.seed
@@ -271,6 +271,7 @@ CONFIG_PACKAGE_kmod-libphy=y
 CONFIG_PACKAGE_kmod-macvlan=y
 CONFIG_PACKAGE_kmod-mii=y
 CONFIG_PACKAGE_kmod-multimedia-input=y
+CONFIG_PACKAGE_kmod-nat46=y
 CONFIG_PACKAGE_kmod-nf-conncount=y
 CONFIG_PACKAGE_kmod-nf-conntrack-netlink=y
 CONFIG_PACKAGE_kmod-nf-ipt=y


### PR DESCRIPTION
I'm using a R5S as a router, and our ISP provides IPv4 connectivity using MAP-E. Unfortunately, this image didn't come with kmod-nat46 (a requirement of the [map](https://openwrt.org/packages/pkgdata/map) package), so I had to compile my own. I see that the official builds will be available soon? so I'm not sure how long this fork will last. Let me know if there's something I should fix before this can be merged (or if there's a better way to do this without merging?)

Thanks for the image, it's working perfectly now :+1: 